### PR TITLE
Use root_path instead of prefix

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,7 +56,7 @@ jobs:
   deploy:
     needs: docker
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') # manual trigger or tag push
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
 
     steps:
       - name: Manual deploy

--- a/src/api.py
+++ b/src/api.py
@@ -86,7 +86,7 @@ class TranslationMetadata(BaseModel):
 
 
 # Create API router
-api_router = APIRouter(prefix="/api", tags=["api"])
+api_router = APIRouter(tags=["api"])
 
 
 @api_router.get("/translations", response_model=list[TranslationInfo], tags=["translations"])

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,8 @@ class Settings(BaseSettings):
     env: str = Field(default="development", alias="APP_ENV")
     debug: bool = Field(default=False, alias="DEBUG")
 
+    root_path: str = "/api"
+
     postgres_host: str = Field(default="localhost", alias="POSTGRES_HOST")
     postgres_port: int = Field(default=5432, alias="POSTGRES_PORT")
     postgres_db: str = Field(default="bible", alias="POSTGRES_DB")

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ app = FastAPI(
     license_info={
         "name": "MIT",
     },
+    root_path=settings.root_path,
 )
 
 # Configure CORS

--- a/src/users/api.py
+++ b/src/users/api.py
@@ -144,7 +144,7 @@ class User2FA:
         return raw_code == code
 
 
-auth_router = APIRouter(prefix="/api", tags=["auth"])
+auth_router = APIRouter(tags=["auth"])
 
 
 @auth_router.post(


### PR DESCRIPTION
We can access `/api/docs` for openapi docs with this change.